### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.804.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>

--- a/src/VirtoCommerce.CyberSourcePayment.Core/VirtoCommerce.CyberSourcePayment.Core.csproj
+++ b/src/VirtoCommerce.CyberSourcePayment.Core/VirtoCommerce.CyberSourcePayment.Core.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CyberSource.Rest.Client.NetStandard" Version="0.0.1.40" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.821.0" />
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.830.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.812.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.917.0" />
+    <PackageReference Include="CyberSource.Rest.Client.NetStandard" Version="0.0.1.53" />
+    
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CyberSourcePayment.Data/Providers/CyberSourcePaymentMethod.cs
+++ b/src/VirtoCommerce.CyberSourcePayment.Data/Providers/CyberSourcePaymentMethod.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CyberSource.Model;
 using Newtonsoft.Json;
@@ -30,46 +31,15 @@ public class CyberSourcePaymentMethod(
     public override PaymentMethodType PaymentMethodType => PaymentMethodType.Standard;
     public override bool AllowCartPayment => true;
 
-    #region overrides
-
-    public override ProcessPaymentRequestResult ProcessPayment(ProcessPaymentRequest request)
+    public override Task<ValidatePostProcessRequestResult> ValidatePostProcessRequestAsync(NameValueCollection queryString, CancellationToken cancellationToken = default)
     {
-        return ProcessPaymentAsync(request).GetAwaiter().GetResult();
-    }
-
-    public override PostProcessPaymentRequestResult PostProcessPayment(PostProcessPaymentRequest request)
-    {
-        return PostProcessPaymentAsync(request).GetAwaiter().GetResult();
-    }
-
-    public override ValidatePostProcessRequestResult ValidatePostProcessRequest(NameValueCollection queryString)
-    {
-        return new ValidatePostProcessRequestResult
+        return Task.FromResult(new ValidatePostProcessRequestResult
         {
             IsSuccess = true,
-        };
+        });
     }
 
-    public override CapturePaymentRequestResult CaptureProcessPayment(CapturePaymentRequest context)
-    {
-        return CaptureProcessPaymentAsync(context).GetAwaiter().GetResult();
-    }
-
-    public override RefundPaymentRequestResult RefundProcessPayment(RefundPaymentRequest context)
-    {
-        return RefundProcessPaymentAsync(context).GetAwaiter().GetResult();
-    }
-
-    public override VoidPaymentRequestResult VoidProcessPayment(VoidPaymentRequest request)
-    {
-        return VoidProcessPaymentAsync(request).GetAwaiter().GetResult();
-    }
-
-    #endregion
-
-    #region protected async methods
-
-    protected virtual async Task<ProcessPaymentRequestResult> ProcessPaymentAsync(ProcessPaymentRequest request)
+    public override async Task<ProcessPaymentRequestResult> ProcessPaymentAsync(ProcessPaymentRequest request, CancellationToken cancellationToken = default)
     {
         var store = (Store)request.Store;
 
@@ -106,7 +76,7 @@ public class CyberSourcePaymentMethod(
         return result;
     }
 
-    protected virtual async Task<PostProcessPaymentRequestResult> PostProcessPaymentAsync(PostProcessPaymentRequest request)
+    public override async Task<PostProcessPaymentRequestResult> PostProcessPaymentAsync(PostProcessPaymentRequest request, CancellationToken cancellationToken = default)
     {
         var token = request.Parameters.Get("token");
         var payment = (PaymentIn)request.Payment;
@@ -120,7 +90,7 @@ public class CyberSourcePaymentMethod(
         return result;
     }
 
-    protected virtual async Task<CapturePaymentRequestResult> CaptureProcessPaymentAsync(CapturePaymentRequest context)
+    public override async Task<CapturePaymentRequestResult> CaptureProcessPaymentAsync(CapturePaymentRequest context, CancellationToken cancellationToken = default)
     {
         var captureRequest = PrepareCapturePaymentRequest(context);
         var captureResult = await cyberSourceClient.CapturePayment(captureRequest);
@@ -147,7 +117,7 @@ public class CyberSourcePaymentMethod(
         return result;
     }
 
-    protected virtual async Task<RefundPaymentRequestResult> RefundProcessPaymentAsync(RefundPaymentRequest context)
+    public override async Task<RefundPaymentRequestResult> RefundProcessPaymentAsync(RefundPaymentRequest context, CancellationToken cancellationToken = default)
     {
         var payment = (PaymentIn)context.Payment;
         var refundRequest = PrepareRefundPaymentRequest(payment, context);
@@ -166,7 +136,7 @@ public class CyberSourcePaymentMethod(
         return result;
     }
 
-    protected virtual async Task<VoidPaymentRequestResult> VoidProcessPaymentAsync(VoidPaymentRequest request)
+    public override async Task<VoidPaymentRequestResult> VoidProcessPaymentAsync(VoidPaymentRequest request, CancellationToken cancellationToken = default)
     {
         var payment = (PaymentIn)request.Payment;
         var transactionRequest = PrepareVoidPaymentRequest(payment);
@@ -187,8 +157,6 @@ public class CyberSourcePaymentMethod(
 
         return result;
     }
-
-    #endregion
 
     #region prepare requests
 

--- a/src/VirtoCommerce.CyberSourcePayment.Data/VirtoCommerce.CyberSourcePayment.Data.csproj
+++ b/src/VirtoCommerce.CyberSourcePayment.Data/VirtoCommerce.CyberSourcePayment.Data.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.917.0" />
+    
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CyberSourcePayment.Core\VirtoCommerce.CyberSourcePayment.Core.csproj" />

--- a/src/VirtoCommerce.CyberSourcePayment.Web/VirtoCommerce.CyberSourcePayment.Web.csproj
+++ b/src/VirtoCommerce.CyberSourcePayment.Web/VirtoCommerce.CyberSourcePayment.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/VirtoCommerce.CyberSourcePayment.Web/module.manifest
+++ b/src/VirtoCommerce.CyberSourcePayment.Web/module.manifest
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
   <id>VirtoCommerce.CyberSourcePayment</id>
-  <version>3.804.0</version>
+  <version>3.1000.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.917.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Core" version="3.812.0" />
-    <dependency id="VirtoCommerce.Customer" version="3.821.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.830.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.812.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Orders" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
   </dependencies>
   <title>CyberSource Payment Module</title>
   <description>Integrates CyberSource's payment solutions into your Virto Commerce platform</description>

--- a/tests/VirtoCommerce.CyberSourcePayment.Tests/VirtoCommerce.CyberSourcePayment.Tests.csproj
+++ b/tests/VirtoCommerce.CyberSourcePayment.Tests/VirtoCommerce.CyberSourcePayment.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -8,13 +8,13 @@
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.CyberSourcePayment.Core\VirtoCommerce.CyberSourcePayment.Core.csproj" />


### PR DESCRIPTION
## Description
Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CyberSourcePayment_3.1000.0-pr-8-92e3.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because this is a runtime/framework and dependency upgrade plus payment-method API signature changes (async + cancellation tokens), which can cause build/runtime or integration regressions despite minimal business-logic changes.
> 
> **Overview**
> Upgrades the module to **.NET 10** and bumps the module version to `3.1000.0`, aligning `module.manifest` platform/dependency versions with the `3.100x` VirtoCommerce line.
> 
> Updates NuGet dependencies (notably `CyberSource.Rest.Client.NetStandard`, VirtoCommerce core modules, `System.IdentityModel.Tokens.Jwt`) and modernizes tests by moving to `xunit.v3` plus newer `Microsoft.NET.Test.Sdk`/`coverlet`.
> 
> Refactors `CyberSourcePaymentMethod` to remove sync wrapper overrides and instead implement the newer `*Async(..., CancellationToken)` overrides (including `ValidatePostProcessRequestAsync`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92e34ce3e83537c7537022ad0aebe1298e254b0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->