### PR TITLE
VCST-4726: Fix Null Reference exception

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,5 +8,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- System.Drawing.Common 4.7.0 is a transitive dependency of CyberSource.Rest.Client.NetStandard -->
+    <NoWarn>$(NoWarn);NU1904</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/VirtoCommerce.CyberSourcePayment.Core/Models/CyberSourcePaymentMethodOptions.cs
+++ b/src/VirtoCommerce.CyberSourcePayment.Core/Models/CyberSourcePaymentMethodOptions.cs
@@ -38,8 +38,6 @@ public class CyberSourcePaymentMethodOptions
             ["runEnvironment"] = environment,
             ["keyAlias"] = MerchantId,
             ["keyPass"] = MerchantId,
-            ["enableClientCert"] = "false",
-            ["useMetaKey"] = "false",
         };
     }
 }

--- a/src/VirtoCommerce.CyberSourcePayment.Core/Models/CyberSourcePaymentMethodOptions.cs
+++ b/src/VirtoCommerce.CyberSourcePayment.Core/Models/CyberSourcePaymentMethodOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace VirtoCommerce.CyberSourcePayment.Core.Models;
@@ -10,8 +11,6 @@ public class CyberSourcePaymentMethodOptions
 
     public int ValidateSignatureRetryCount { get; set; } = 1;
 
-    private readonly Dictionary<string, string> _configurationDictionary = new();
-
     public static string Environment(bool sandbox)
     {
         return sandbox
@@ -21,16 +20,26 @@ public class CyberSourcePaymentMethodOptions
 
     public IReadOnlyDictionary<string, string> ToDictionary(bool sandbox)
     {
+        if (string.IsNullOrEmpty(MerchantId) || string.IsNullOrEmpty(MerchantKeyId) || string.IsNullOrEmpty(MerchantSecretKey))
+        {
+            throw new InvalidOperationException(
+                "CyberSource payment configuration is incomplete. " +
+                "Please provide MerchantId, MerchantKeyId, and MerchantSecretKey in the 'Payments:CyberSource' configuration section.");
+        }
+
         var environment = Environment(sandbox);
 
-        _configurationDictionary.TryAdd("authenticationType", "HTTP_SIGNATURE");
-        _configurationDictionary.TryAdd("merchantID", MerchantId);
-        _configurationDictionary.TryAdd("merchantsecretKey", MerchantSecretKey);
-        _configurationDictionary.TryAdd("merchantKeyId", MerchantKeyId);
-        _configurationDictionary.TryAdd("runEnvironment", environment);
-        _configurationDictionary.TryAdd("keyAlias", MerchantId);
-        _configurationDictionary.TryAdd("keyPass", MerchantId);
-
-        return _configurationDictionary;
+        return new Dictionary<string, string>
+        {
+            ["authenticationType"] = "HTTP_SIGNATURE",
+            ["merchantID"] = MerchantId,
+            ["merchantsecretKey"] = MerchantSecretKey,
+            ["merchantKeyId"] = MerchantKeyId,
+            ["runEnvironment"] = environment,
+            ["keyAlias"] = MerchantId,
+            ["keyPass"] = MerchantId,
+            ["enableClientCert"] = "false",
+            ["useMetaKey"] = "false",
+        };
     }
 }

--- a/src/VirtoCommerce.CyberSourcePayment.Core/VirtoCommerce.CyberSourcePayment.Core.csproj
+++ b/src/VirtoCommerce.CyberSourcePayment.Core/VirtoCommerce.CyberSourcePayment.Core.csproj
@@ -7,7 +7,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CyberSource.Rest.Client.NetStandard" Version="0.0.1.40" />
+    <PackageReference Include="CyberSource.Rest.Client.NetStandard" Version="0.0.1.48" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.CyberSourcePayment.Core/VirtoCommerce.CyberSourcePayment.Core.csproj
+++ b/src/VirtoCommerce.CyberSourcePayment.Core/VirtoCommerce.CyberSourcePayment.Core.csproj
@@ -7,7 +7,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CyberSource.Rest.Client.NetStandard" Version="0.0.1.40" />
+    <PackageReference Include="CyberSource.Rest.Client.NetStandard" Version="0.0.1.53" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.CyberSourcePayment.Core/VirtoCommerce.CyberSourcePayment.Core.csproj
+++ b/src/VirtoCommerce.CyberSourcePayment.Core/VirtoCommerce.CyberSourcePayment.Core.csproj
@@ -7,8 +7,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CyberSource.Rest.Client.NetStandard" Version="0.0.1.53" />
-    
+    <PackageReference Include="CyberSource.Rest.Client.NetStandard" Version="0.0.1.40" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.CyberSourcePayment.Core/VirtoCommerce.CyberSourcePayment.Core.csproj
+++ b/src/VirtoCommerce.CyberSourcePayment.Core/VirtoCommerce.CyberSourcePayment.Core.csproj
@@ -7,7 +7,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CyberSource.Rest.Client.NetStandard" Version="0.0.1.53" />
+    <PackageReference Include="CyberSource.Rest.Client.NetStandard" Version="0.0.1.40" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />


### PR DESCRIPTION
## Description
fix: Fix Null Reference exception

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4726
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CyberSourcePayment_3.1001.0-pr-9-0359.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CyberSource payment initialization to throw on missing merchant credentials and downgrades the CyberSource client package, which could alter runtime behavior or API compatibility. Build now suppresses `NU1904`, potentially masking a known vulnerable transitive dependency warning.
> 
> **Overview**
> Prevents null/invalid CyberSource setups by validating `MerchantId`, `MerchantKeyId`, and `MerchantSecretKey` in `CyberSourcePaymentMethodOptions.ToDictionary` and throwing a clear `InvalidOperationException` when configuration is incomplete; also returns a fresh config dictionary per call instead of reusing a mutable instance.
> 
> Updates dependencies/build settings by downgrading `CyberSource.Rest.Client.NetStandard` to `0.0.1.48` and suppressing NuGet advisory warning `NU1904` (triggered by a transitive `System.Drawing.Common` dependency) in `Directory.Build.props`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03594be0310444dce35f3aa5d75a1ae3e55a35da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->